### PR TITLE
Add GitHub Actions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy Docusaurus to GitHub Pages](https://github.com/colibriproject-dev/colibri-sdk-go-docs/actions/workflows/pages.yml/badge.svg)](https://github.com/colibriproject-dev/colibri-sdk-go-docs/actions/workflows/pages.yml)
+
 # Website
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
@@ -24,18 +26,4 @@ $ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+___


### PR DESCRIPTION
Include a status badge for the GitHub Pages deployment workflow in the README. Removes redundant deployment instructions for better clarity and to avoid duplication. This highlights the automation setup directly in the project documentation.