### PR TITLE
Rename and restructure docs for clarity and new content

### DIFF
--- a/docs/getting-started/add-on-existing-project.mdx
+++ b/docs/getting-started/add-on-existing-project.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_position: 3
+title: Adicionando em um projeto existente
+---
+
+Para configurar o projeto **colibri-sdk-go** em um projeto existente, é necessário fazer algumas configurações manuais para que tudo funciona perfeitamente
+
+## Adicionar dependência
+
+```shell
+go get github.com/colibriproject-dev/colibri-sdk-go
+```
+
+## Definir variáveis de ambiente
+
+Existem algumas variáveis de ambiente mínimas dnecessárias para configuração do `colibri-sdk-go` que sao listadas abaixo
+
+```dotenv showLineNumbers
+ENVIRONMENT=development
+APP_NAME=my-awesome-go-project
+APP_TYPE=service
+CLOUD=gcp
+```
+
+Na linha `1` definimos a variável `ENVIRONMENT` que define qual ambiente estamos executando o projeto, ela aceita os valores:
+* **development**: Ambiente de desenvolvimento local, quando definica prepara algumas configurações para execução local, como formatação dos logs.
+* **sandbox**: Ambiente de validação do projeto.
+* **test**: é definido quando estamos executando os testes unitários ou de integração.
+* **production**: Ambiente de produção onde o serviço está sendo executado.
+
+Por padrão, o `colibri-sdk-go` carrega as variáveis de ambientes definidas no arquivo `.env` disponível na raiz de execução do projeto.
+
+## Configurar arquivo `main.go`
+
+```go showLineNumbers
+package main
+
+import (
+	"github.com/colibriproject-dev/colibri-sdk-go"
+	"github.com/colibriproject-dev/colibri-sdk-go/pkg/web/restserver"
+)
+
+func main() {
+	colibri.InitializeApp()
+
+	// my main code
+
+	restserver.ListenAndServe()
+}
+```
+
+Na linha `9` inicializamos o `colibri-sdk-go`, nesse passo é onde as variáveis de ambiente serão carregadas e as definições básicas do projeto serão feitas.
+Na linha `13` inicializados o serviço web, por padrão é utilizada a porta `8080`, mas essa configuração pode ser alterada através da variável de ambiente `PORT`.
+
+## Executando o projeto
+
+Após realizar as configurações, podemos iniciar o projeto através do comando:
+
+```shell
+go run main.go
+```
+
+Se tudo foi configurado corretamente, um log será apresetando como abaixo
+
+```shell
+
+      .   _            _ _ _          _
+     { \/'o;===       | (_) |        (_)
+.----'-/'-/  ___  ___ | |_| |__  _ __ _
+ '-..-| /   / __ / _ \| | | '_ \| '__| |
+    /\/\   | (__| (_) | | | |_) | |  | |
+    '--'    \___ \___/|_|_|_.__/|_|  |_|
+            project
+
+# my-awesome-go-project #
+
+{"time":"2025-05-01T18:00:56.707132641-03:00","level":"INFO","msg":"Initializing GCP","caller":"cloud.Initialize"}
+{"time":"2025-05-01T18:00:56.70717939-03:00","level":"INFO","msg":"Cloud provider connected","caller":"cloud.Initialize"}
+{"time":"2025-05-01T18:00:56.707335553-03:00","level":"INFO","msg":"Registered route [    GET] /health","caller":"restserver.fiberWebServer.injectRoutes"}
+{"time":"2025-05-01T18:00:56.707347852-03:00","level":"INFO","msg":"Registered route [    GET] /api-docs","caller":"restserver.fiberWebServer.injectRoutes"}
+{"time":"2025-05-01T18:00:56.707352964-03:00","level":"INFO","msg":"Service 'WEB-REST' running in 8080 port","caller":"restserver.ListenAndServe"}
+```
+
+Com isso seu projeto está apto a evoluir, parabéns.
+
+___

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 3
-title: Primeiro microserviço
+sidebar_position: 4
+title: Primeiros passos
 ---
 
 ## Criando sua primeira rota

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,6 +4,7 @@ title: Instalação
 ---
 
 Para iniciar um projeto, temos duas formas:
+
 1. Criar um novo projeto diretamente do gerador do Colibri Project.
 2. Incluir a dependência no seu projeto Go criado anteriormente.
 
@@ -16,7 +17,7 @@ Acessar o site [colibri-project.dev.br](https://colibriproject.dev.br) criar seu
 Para adicionar o colibri-sdk-go no seu projeto, basta executar o comando abaixo:
 
 ```shell
-go get -u github.com/colibriproject-dev/colibri-sdk-go
+go get github.com/colibriproject-dev/colibri-sdk-go
 ```
 
 ___

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -8,5 +8,6 @@ Para utilizar todo ferramental disponibilizado pelo Colibri Project, você vai p
 - [Go 1.24+](https://go.dev/dl/)
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - Make (opcional)
+- IDE de sua preferência.
 
 ___


### PR DESCRIPTION
Renamed and reorganized "getting started" documentation to improve clarity and navigation. Added a new guide for integrating `colibri-sdk-go` into existing projects, updated titles, sidebar positions, and included minor fixes for commands and environment variable explanations.