### PR TITLE
Add example repository link to getting-started guide

### DIFF
--- a/docs/getting-started/examples-repository.mdx
+++ b/docs/getting-started/examples-repository.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 5
+title: Projetos de exemplos
+---
+
+## colibri-sdk-go-examples
+
+No repositório de [exemplos](https://github.com/colibriproject-dev/colibri-sdk-go-examples), temos dois projetos onde é demonstrado todo o poder do `colibri-sdk-go`.
+Nele temos dois serviços demonstrando a utilização de comunicação síncrona e assíncrona, utilização de banco de dados e muito mais.
+
+___


### PR DESCRIPTION
Added a reference to the example repository in the getting-started guide, showcasing projects that demonstrate synchronous and asynchronous communication, database usage, and more. This helps developers understand the practical applications of `colibri-sdk-go`.