### PR TITLE
Simplify observability initialization documentation.

### DIFF
--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -9,12 +9,9 @@ Este pacote fornece uma camada completa de observabilidade para aplicações, in
 
 ### 1. Inicialização
 
-``` go
-// Inicialização do monitoramento
-monitoring.Initialize()
-```
+A configuração é realizada automaticamente ao iniciar o `colibri-sdk-go`.
 
-A inicialização configura automaticamente:
+São configurados os seguintes componentes:
 - Conexão com [NewRelic](https://newrelic.com/) e [OpenTelemetry](https://opentelemetry.io/)
 - Configuração de métricas padrão
 


### PR DESCRIPTION
Updated the documentation to clarify that monitoring initialization is handled automatically by `colibri-sdk-go`. Removed the code snippet and adjusted the description to list preconfigured components.