### PR TITLE
Rename category labels to Portuguese in JSON files.

### DIFF
--- a/docs/features/_category_.json
+++ b/docs/features/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Features",
+  "label": "Funcionalidades",
   "position": 3,
   "link": {
     "type": "generated-index",

--- a/docs/getting-started/_category_.json
+++ b/docs/getting-started/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Getting Started",
+  "label": "Começando",
   "position": 2,
   "link": {
     "type": "generated-index",

--- a/docs/publishing/_category_.json
+++ b/docs/publishing/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Publishing",
+  "label": "Publicando",
   "position": 4,
   "link": {
     "type": "generated-index",


### PR DESCRIPTION
Updated the labels in the category configuration files to Portuguese for consistency with the localized content. The affected labels include "Publishing," "Getting Started," and "Features."