### PR TITLE
Add proxy configuration example to HTTP client documentation.

### DIFF
--- a/docs/features/client-http.md
+++ b/docs/features/client-http.md
@@ -25,7 +25,8 @@ config := &RestClientConfig{
     BaseURL:             "http://api.exemplo.com",
     Timeout:             30,
     Retries:             3,
-    RetrySleepInSeconds: 2
+    RetrySleepInSeconds: 2,
+	ProxyURL:            "http://proxy.example.com:8080",
 }
 
 client := NewRestClient(config)


### PR DESCRIPTION
Updated the HTTP client configuration guide to include an example of setting a `ProxyURL` parameter, enhancing clarity for proxy setup in client requests.