### PR TITLE
Remove New Relic references from observability documentation (#31)

### DIFF
--- a/docs/features/async-communication.md
+++ b/docs/features/async-communication.md
@@ -79,7 +79,7 @@ Abstração dos provedores de nuvem abaixo:
 
 ### 2. Observabilidade
 
-- Integração com [NewRelic](https://newrelic.com/)/[OpenTelemetry](https://opentelemetry.io/)
+- Integração com [OpenTelemetry](https://opentelemetry.io/)
 - Logging estruturado
 - Rastreamento de mensagens
 

--- a/docs/features/cache.md
+++ b/docs/features/cache.md
@@ -18,7 +18,7 @@ cacheDB.Initialize()
 
 Características da inicialização:
 - Conexão automática com [Redis](https://redis.io).
-- Integração com [NewRelic](https://newrelic.com/)/[OpenTelemetry](https://opentelemetry.io/) para monitoramento.
+- Integração com [OpenTelemetry](https://opentelemetry.io/) para monitoramento.
 
 Variáveis de ambiente necessárias:
 - `CACHE_URI`: host do banco de dados.
@@ -90,7 +90,7 @@ pedidoCache := NewCache[Pedido]("pedidos", 30 * time.Minute)
 
 ### 2. Observabilidade
 
-- Monitoramento via [NewRelic](https://newrelic.com/)/[OpenTelemetry](https://opentelemetry.io/).
+- Monitoramento via [OpenTelemetry](https://opentelemetry.io/).
 - Logging estruturado de operações.
 - Rastreamento de erros.
 

--- a/docs/features/database.md
+++ b/docs/features/database.md
@@ -156,7 +156,7 @@ usuario, err := NewQuery[User](ctx,
 ```
 
 ### 2. Observabilidade
-- Integração com [NewRelic](https://newrelic.com/)/[OpenTelemetry](https://opentelemetry.io/) para monitoramento
+- Integração com [OpenTelemetry](https://opentelemetry.io/) para monitoramento
 - Logging estruturado de operações
 - Rastreamento de transações
 

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -3,7 +3,7 @@ sidebar_position: 7
 title: Observabilidade
 ---
 
-Este pacote fornece uma camada completa de observabilidade para aplicações, integrando métricas, tracing e logging. São encapsuladas duas versões, uma com [NewRelic](https://newrelic.com/) e outra com [OpenTelemetry](https://opentelemetry.io/), oferecendo recursos para monitoramento de transações, segmentos e erros.
+Este pacote fornece uma camada completa de observabilidade para aplicações, integrando métricas, tracing e logging. É encapsulada a implementação com [OpenTelemetry](https://opentelemetry.io/), oferecendo recursos para monitoramento de transações, segmentos e erros.
 
 ## Componentes Principais
 
@@ -12,16 +12,8 @@ Este pacote fornece uma camada completa de observabilidade para aplicações, in
 A configuração é realizada automaticamente ao iniciar o `colibri-sdk-go`.
 
 São configurados os seguintes componentes:
-- Conexão com [NewRelic](https://newrelic.com/) e [OpenTelemetry](https://opentelemetry.io/)
+- Conexão [OpenTelemetry](https://opentelemetry.io/)
 - Configuração de métricas padrão
-
-#### Utilizando New Relic
-
-Para utilizar o New Relic, basta adicionar a variável de ambiente:
-
-```dotenv showLineNumber
-NEW_RELIC_LICENSE=XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
 
 #### Utilizando OpenTelemetry
 

--- a/docs/features/storage.md
+++ b/docs/features/storage.md
@@ -60,7 +60,7 @@ err := storage.DeleteFile(
 
 ### 2. Observabilidade
 - 
-- Integração com [NewRelic](https://newrelic.com/)/[OpenTelemetry](https://opentelemetry.io/)
+- Integração com [OpenTelemetry](https://opentelemetry.io/)
 - Monitoramento de transações
 - Logging estruturado
 


### PR DESCRIPTION
Updated the observability documentation to focus solely on OpenTelemetry by removing all references to New Relic. Adjusted examples, descriptions, and environment variable sections for clarity and consistency.