### PR TITLE
Expand async communication documentation with RabbitMQ configuration details

### DIFF
--- a/docs/features/async-communication.md
+++ b/docs/features/async-communication.md
@@ -148,6 +148,19 @@ func (p *ProcessadorAutenticado) Consume(ctx context.Context, msg *ProviderMessa
 }
 ```
 
+## Utilizando RabbitMQ
+
+Para utilizar o RabbitMQ é necessário realizar passar algumas variáveis de ambiente adicionais:
+
+- `USE_RABBITMQ`: Aceita os valores `true` ou `false`, por padrão é definido como `false`.
+- `RABBITMQ_URL`: URL para acessar o serviço do RabbitMQ no formato `amqp://guest:guest@localhost:5672/`
+
+Ao se utilizar o RabbitMQ, filas de `DLQ` são criadas automaticamente para as mensagens com erro sejam encaminhadas para elas.
+
+> Por padrão ao definir o RabbitMQ como broker padrão para utilização, é ignorado os demais serviços como `SNS/SQS` e `PubSub`.
+
+
+
 ## Boas Práticas
 
 1. **Nomenclatura de Tópicos/Filas**:


### PR DESCRIPTION
Added a section detailing RabbitMQ setup, including new environment variables `USE_RABBITMQ` and `RABBITMQ_URL`. Explained default behaviors, automatic `DLQ` handling, and the impact on other broker services.